### PR TITLE
Improve `projects.ls` output

### DIFF
--- a/catapult/__main__.py
+++ b/catapult/__main__.py
@@ -4,12 +4,13 @@ Collection of tasks for *catapult*.
 import logging
 import os
 import sys
-import invoke
+
 import boto3
+import invoke
 
 from catapult.deploy import deploy
-from catapult.release import release
 from catapult.projects import projects
+from catapult.release import release
 
 __version__ = "0.1"
 

--- a/catapult/deploy.py
+++ b/catapult/deploy.py
@@ -1,15 +1,15 @@
 """
 Commands to manage deployments.
 """
-from datetime import datetime
-import dataclasses
-import sys
-
-import invoke
 import logging
+import sys
+from datetime import datetime
 
-from catapult.release import get_releases, get_release, put_release
+import dataclasses
+import invoke
+
 from catapult import utils
+from catapult.release import get_release, get_releases, put_release
 
 LOG = logging.getLogger(__name__)
 

--- a/catapult/projects.py
+++ b/catapult/projects.py
@@ -2,79 +2,151 @@
 Commands to inspect projects.
 """
 import logging
+from datetime import datetime
+from enum import Enum
+from operator import itemgetter
+from typing import NamedTuple, Optional
 
-from botocore.exceptions import ClientError
 import invoke
+import pygit2 as git
 
 from catapult import utils
-from catapult.release import _get_release as get_release, InvalidRelease
+from catapult.release import InvalidRelease, Release
+from catapult.release import _get_release as get_release
 
 LOG = logging.getLogger(__name__)
 
 
-@invoke.task(default=True)
+class ProjectType(Enum):
+    release = "release"
+    deploy = "deploy"
+
+
+class Project(NamedTuple):
+    name: str
+    type: ProjectType
+    env_name: Optional[str]
+    version: int
+    timestamp: datetime
+    commit: str
+    contains: Optional[bool]
+
+
+@invoke.task(
+    default=True,
+    help={
+        "contains": "Full SHA-1 hash of a commit in the current repo",
+        "sort": "comma-separated list of fields by which to sort the output, eg `timestamp,name`",
+        "reverse": "reverse-sort the output",
+    },
+)
 @utils.require_2fa
-def ls(_):
+def ls(_, contains=None, sort=None, reverse=False):
     """
     List all the projects managed with catapult.
+
+    Optionally pass a full SHA-1 hash of a commit in the current repo,
+    and each release/deploy will be marked with 'Y' if it contains that
+    commit, 'N' if it doesn't, or '?' if it can't be determined (eg
+    perhaps the App belongs to another repo).
     """
+
+    contains_oid = None
+    repo = None
+
+    if contains:
+        contains_oid = git.Oid(hex=contains)
+        repo = utils.git_repo()
+        if contains_oid not in repo:
+            raise Exception(f"Commit {contains_oid} does not exist in repo")
+
+    valid_sort_keys = list(Project._fields)
+    if not contains:
+        valid_sort_keys.remove("contains")
+
+    sort_keys = [] if sort is None else sort.split(",")
+    if any(sort_key not in valid_sort_keys for sort_key in sort_keys):
+        raise Exception(
+            f"Invalid sort key in {sort!r}. Valid sort keys: {valid_sort_keys}"
+        )
+
     client = utils.s3_client()
-
-    projects = []
-
     config = utils.get_config()
     bucket = config["release"]["s3_bucket"]
     deploys = config["deploy"]
 
     resp = client.list_objects_v2(Bucket=bucket)
-    for data in resp.get("Contents", []):
-        name = data["Key"]
 
-        projects.append(name)
-
-    projects = sorted(projects)
+    project_names = sorted(data["Key"] for data in resp.get("Contents", []))
 
     _projects = []
 
-    for name in projects:
+    for name in project_names:
         try:
             release = get_release(client, bucket, name)
         except InvalidRelease:
             continue
 
-        data = {
-            "Name": name,
-            "Latest Release": f"v{release.version} {release.timestamp} ({release.commit})",
-        }
+        _projects.append(
+            Project(
+                name=name,
+                version=release.version,
+                commit=release.commit,
+                timestamp=release.timestamp,
+                type=ProjectType.release,
+                contains=release_contains(repo, release, contains_oid, name)
+                if contains
+                else None,
+                env_name=None,
+            )
+        )
 
         for env_name, cfg in deploys.items():
-            env_version, env_commit, env_timestamp = get_deployed_version(
-                client, cfg["s3_bucket"], name
+            try:
+                deploy = get_release(client, cfg["s3_bucket"], name)
+            except InvalidRelease:
+                continue
+
+            _projects.append(
+                Project(
+                    name=name,
+                    version=deploy.version,
+                    commit=deploy.commit,
+                    timestamp=deploy.timestamp,
+                    type=ProjectType.deploy,
+                    env_name=env_name,
+                    contains=release_contains(repo, deploy, contains_oid, name)
+                    if contains
+                    else None,
+                )
             )
 
-            data[env_name.title()] = f"v{env_version} {env_timestamp} ({env_commit})"
+    project_dicts = []
+    for project in _projects:
+        project_dict = project._asdict()
+        if not contains:
+            project_dict.pop("contains")
+        project_dicts.append(project_dict)
 
-        _projects.append(data)
+    if sort_keys:
+        project_dicts.sort(key=itemgetter(*sort_keys), reverse=reverse)
 
-    projects = _projects
-
-    utils.printfmt(projects)
+    utils.printfmt(project_dicts, tabular=True)
 
 
-def get_deployed_version(client, bucket_name, project_name):
+def release_contains(repo: git.Repository, release: Release, commit_oid: git.Oid, name: str):
+    release_oid = git.Oid(hex=release.commit)
     try:
-        deploy = get_release(client, bucket_name, project_name)
+        in_release = (
+            "Y" if utils.commit_contains(repo, release_oid, commit_oid) else "N"
+        )
+    except git.GitError as e:
+        LOG.warning(
+            f"Repo: [{repo.workdir}], Error: [{repr(e)}], Project: [{name}]"
+        )
+        in_release = "?"
 
-    except ClientError as e:
-        if e.response["Error"]["Code"] == "AccessDenied":
-            LOG.warning(f"Access denied on {bucket_name} for {project_name}: {str(e)}")
-            return "???", "???", "???"
-        raise
-
-    except InvalidRelease:
-        return "X", "X", "X"
-
-    return deploy.version, deploy.commit, deploy.timestamp
+    return in_release
 
 
 projects = invoke.Collection("projects", ls)

--- a/catapult/projects.py
+++ b/catapult/projects.py
@@ -39,10 +39,11 @@ class Project(NamedTuple):
         "contains": "Full SHA-1 hash of a commit in the current repo",
         "sort": "comma-separated list of fields by which to sort the output, eg `timestamp,name`",
         "reverse": "reverse-sort the output",
+        "only": "comma-separated list of apps to list",
     },
 )
 @utils.require_2fa
-def ls(_, contains=None, sort=None, reverse=False):
+def ls(_, contains=None, sort=None, reverse=False, only=None):
     """
     List all the projects managed with catapult.
 
@@ -71,6 +72,9 @@ def ls(_, contains=None, sort=None, reverse=False):
             f"Invalid sort key in {sort!r}. Valid sort keys: {valid_sort_keys}"
         )
 
+    if only is not None:
+        only = only.split(",")
+
     client = utils.s3_client()
     config = utils.get_config()
     bucket = config["release"]["s3_bucket"]
@@ -85,6 +89,9 @@ def ls(_, contains=None, sort=None, reverse=False):
     now = datetime.now(tz=timezone.utc)
 
     for name in project_names:
+        if only and name not in only:
+            continue
+
         try:
             release = get_release(client, bucket, name)
         except InvalidRelease:

--- a/catapult/projects.py
+++ b/catapult/projects.py
@@ -126,6 +126,7 @@ def ls(_, contains=None, sort=None, reverse=False):
         project_dict = project._asdict()
         if not contains:
             project_dict.pop("contains")
+        project_dict["type"] = project_dict["type"].name
         project_dicts.append(project_dict)
 
     if sort_keys:

--- a/catapult/release.py
+++ b/catapult/release.py
@@ -1,12 +1,12 @@
 """
 Commands to manage releases.
 """
-import dataclasses
-from datetime import datetime
-import logging
 import json
+import logging
 import sys
+from datetime import datetime
 
+import dataclasses
 import invoke
 import pytz
 
@@ -34,7 +34,7 @@ class InvalidRelease(Exception):
     """
 
 
-def _get_release(client, bucket, key, version_id=None):
+def _get_release(client, bucket, key, version_id=None) -> Release:
     """
     Fetches a release from a S3 object.
 

--- a/catapult/utils.py
+++ b/catapult/utils.py
@@ -50,9 +50,6 @@ class JsonEncoder(json.JSONEncoder):
         if isinstance(o, datetime):
             return o.isoformat()
 
-        elif isinstance(o, enum.Enum):
-            return o.name
-
         elif dataclasses.is_dataclass(o):
             return dataclasses.asdict(o)
 
@@ -114,9 +111,6 @@ def to_human(data):
         table = [[h, data[h]] for h in sorted(data.keys())]
 
         text = tabulate(table, [], tablefmt="simple")
-
-    elif isinstance(data, enum.Enum):
-        text = str(data.name)
 
     else:
         text = str(data)

--- a/catapult/utils.py
+++ b/catapult/utils.py
@@ -1,21 +1,22 @@
-from datetime import datetime
-import dataclasses
 import enum
-from functools import partial
 import json
 import logging
-import pathlib
 import os
+import pathlib
 import sys
+from datetime import datetime
+from functools import partial
+from typing import Any, List, Mapping
+
 import boto3
-import pygit2 as git
-from tabulate import tabulate
-import wrapt
-from typing import List
 import colorama
+import dataclasses
+import emoji
+import pygit2 as git
 import termcolor
 import toml
-import emoji
+import wrapt
+from tabulate import tabulate
 
 from catapult import config
 
@@ -48,6 +49,9 @@ class JsonEncoder(json.JSONEncoder):
     def default(self, o):  # pylint: disable=method-hidden
         if isinstance(o, datetime):
             return o.isoformat()
+
+        elif isinstance(o, enum.Enum):
+            return o.name
 
         elif dataclasses.is_dataclass(o):
             return dataclasses.asdict(o)
@@ -111,19 +115,32 @@ def to_human(data):
 
         text = tabulate(table, [], tablefmt="simple")
 
+    elif isinstance(data, enum.Enum):
+        text = str(data.name)
+
     else:
         text = str(data)
 
     return text
 
 
+def to_human_tabular(rows: List[Mapping[str, Any]]):
+    formatted_rows = [
+        {key: "" if value is None else to_human(value) for key, value in row.items()}
+        for row in rows
+    ]
+
+    return tabulate(formatted_rows, headers="keys", tablefmt="grid")
+
+
 FORMATTERS = {
     "human": to_human,
+    "human_tabular": to_human_tabular,
     "json": partial(json.dumps, indent=2, sort_keys=True, cls=JsonEncoder),
 }
 
 
-def printfmt(data):
+def printfmt(data, tabular=False):
     fmt_name = os.environ.get("CATAPULT_FORMAT")
 
     if fmt_name is None:
@@ -132,6 +149,9 @@ def printfmt(data):
 
         else:
             fmt_name = "json"
+
+    if tabular and fmt_name == "human":
+        fmt_name = "human_tabular"
 
     fmt = FORMATTERS.get(fmt_name)
     if fmt is None:
@@ -233,6 +253,17 @@ def get_author(repo):
         return None
 
     return emails[0]
+
+
+def commit_contains(
+    repo: git.Repository, commit: git.Oid, maybe_ancestor: git.Oid
+) -> bool:
+    # Does `commit` contain `maybe_ancestor`?
+
+    if commit == maybe_ancestor:
+        return True
+
+    return repo.descendant_of(commit, maybe_ancestor)
 
 
 class InvalidRange(Exception):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ boto3==1.7.48
 colorama==0.4.1
 dataclasses==0.6
 invoke==1.0.0
-pygit2==0.27.1
+pygit2==0.28.2
 pytz==2018.5
 tabulate==0.8.2
 emoji==0.5.1

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(
     name="catapult",

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -1,12 +1,12 @@
-from datetime import datetime
 import json
+from datetime import datetime
 from unittest import mock
 
 import boto3
+import pytz
 from freezegun import freeze_time
 from invoke import MockContext, Result
 from moto import mock_s3
-import pytz
 from testfixtures import compare
 
 from catapult import release


### PR DESCRIPTION
Addresses #13.

This also adds `--contains` and `--sort` (and `--reverse`) to make the
output more useful.

Additonally tidies imports with isort.


New human readable output looks like this:
```
+-----------+---------+------------+-----------+---------------------------+------------------------------------------+------------+
| name      | type    | env_name   |   version | timestamp                 | commit                                   | contains   |
+===========+=========+============+===========+===========================+==========================================+============+
| some_app  | release |            |        64 | 2019-03-27 17:40:45+00:00 | dd42d2361eee62b48270c30ac612b7d84e4cf470 | N          |
+-----------+---------+------------+-----------+---------------------------+------------------------------------------+------------+
| some_app  | deploy  | staging    |        64 | 2019-03-27 17:42:54+00:00 | dd42d2361eee62b48270c30ac612b7d84e4cf470 | N          |
+-----------+---------+------------+-----------+---------------------------+------------------------------------------+------------+
| some_app  | deploy  | production |        64 | 2019-03-28 11:09:54+00:00 | dd42d2361eee62b48270c30ac612b7d84e4cf470 | N          |
+-----------+---------+------------+-----------+---------------------------+------------------------------------------+------------+
| other_app | release |            |        28 | 2019-07-15 11:07:28+00:00 | 275e0cf0141a3451963aef589f52f35959a43386 | N          |
+-----------+---------+------------+-----------+---------------------------+------------------------------------------+------------+
| other_app | deploy  | staging    |        28 | 2019-07-15 11:13:57+00:00 | 275e0cf0141a3451963aef589f52f35959a43386 | N          |
+-----------+---------+------------+-----------+---------------------------+------------------------------------------+------------+
| other_app | deploy  | production |        27 | 2019-07-02 09:33:22+00:00 | dbe3b226022038d2caa540be3ee0f3771e4eace9 | N          |
+-----------+---------+------------+-----------+---------------------------+------------------------------------------+------------+
| app_three | release |            |        11 | 2019-06-11 17:01:25+00:00 | e8f2ead9005f202ce255c379d2da66241ce5c750 | N          |
+-----------+---------+------------+-----------+---------------------------+------------------------------------------+------------+
| app_three | deploy  | staging    |        11 | 2019-06-11 17:03:00+00:00 | e8f2ead9005f202ce255c379d2da66241ce5c750 | N          |
+-----------+---------+------------+-----------+---------------------------+------------------------------------------+------------+
| app_three | deploy  | production |        11 | 2019-06-11 17:25:26+00:00 | e8f2ead9005f202ce255c379d2da66241ce5c750 | N          |
+-----------+---------+------------+-----------+---------------------------+------------------------------------------+------------+
```