### PR TITLE
use yellow instead of warning

### DIFF
--- a/catapult/deploy.py
+++ b/catapult/deploy.py
@@ -88,7 +88,7 @@ def start(
         if release.rollback:
             ok = utils.confirm(
                 "Are you sure you want to start a rollback deployment?",
-                style=utils.TextStyle.warning,
+                style=utils.TextStyle.yellow,
             )
 
             if not ok:

--- a/catapult/release.py
+++ b/catapult/release.py
@@ -345,7 +345,7 @@ def new(
         if release.rollback:
             ok = utils.confirm(
                 "Are you sure you want to create a rollback release?",
-                style=utils.TextStyle.warning,
+                style=utils.TextStyle.yellow,
             )
 
             if not ok:


### PR DESCRIPTION
Wrong enum name when printing the warning message for a roolback

```
This is a rollback! ⚠                                                                          
Traceback (most recent call last):                                                            
  File "/home/federico.figus/.pyenv/versions/3.6.8/bin/catapult", line 11, in <module>                                 
    load_entry_point('catapult', 'console_scripts', 'catapult')()                                                                                           
  File "/home/federico.figus/git/src/github.com/tessian/catapult/catapult/__main__.py", line 86, in main               
    _main()                                                
  File "/home/federico.figus/git/src/github.com/tessian/catapult/catapult/__main__.py", line 80, in _main
    executor_class=_Executor,
  File "/home/federico.figus/.local/lib/python3.6/site-packages/invoke/program.py", line 332, in run
    self.execute()
  File "/home/federico.figus/.local/lib/python3.6/site-packages/invoke/program.py", line 480, in execute
    executor.execute(*self.tasks)
  File "/home/federico.figus/.local/lib/python3.6/site-packages/invoke/executor.py", line 133, in execute
    result = call.task(*args, **call.kwargs)
  File "/home/federico.figus/.local/lib/python3.6/site-packages/invoke/tasks.py", line 127, in __call__
    result = self.body(*args, **kwargs)
  File "/home/federico.figus/git/src/github.com/tessian/catapult/catapult/utils.py", line 425, in require_2fa
    return wrapped(*args, **kwargs)
  File "/home/federico.figus/git/src/github.com/tessian/catapult/catapult/deploy.py", line 91, in start
    style=utils.TextStyle.warning,
  File "/home/federico.figus/.pyenv/versions/3.6.8/lib/python3.6/enum.py", line 326, in __getattr__
    raise AttributeError(name) from None
AttributeError: warning
```