### PR TITLE
Add image id argument

### DIFF
--- a/catapult/config.py
+++ b/catapult/config.py
@@ -5,6 +5,7 @@ _HOME_PATH = os.path.expanduser("~")
 
 # aws config
 AWS_MFA_DEVICE = os.environ.get("CATAPULT_AWS_MFA_DEVICE")
+
 AWS_PROFILE = os.environ.get("CATAPULT_AWS_PROFILE")
 if not AWS_PROFILE:
     print("The environment variable CATAPULT_AWS_PROFILE is required.")

--- a/catapult/release.py
+++ b/catapult/release.py
@@ -279,6 +279,7 @@ def ls(_, name, last=None):
         "name": "identifies the project to release.",
         "commit": "git ref to build from.",
         "version": "new version",
+        "image-id": "ID of the docker image to release.",
         "image-name": "name of the image to release (default to name)",
         "dry": "prepare a release without committing it",
         "yes": "Automatic yes to prompt",
@@ -295,6 +296,7 @@ def new(
     dry=False,
     yes=False,
     image_name=None,
+    image_id=None,
     rollback=False,
 ):
     """
@@ -317,10 +319,12 @@ def new(
     else:
         version = int(version)
 
-    image_id = _get_image_id(ctx, commit, name=name, image_name=image_name)
     if image_id is None:
-        LOG.critical("Image ID not found")
-        sys.exit(1)
+        image_id = _get_image_id(ctx, commit, name=name, image_name=image_name)
+
+        if image_id is None:
+            LOG.critical("Image not found")
+            sys.exit(1)
 
     changelog = utils.changelog(repo, commit, latest and latest.commit)
 

--- a/resource/README.md
+++ b/resource/README.md
@@ -63,10 +63,10 @@ Create and upload a new release.
 
 * `repository`: *Required.* Path to the git repository where the project
   to release is tracked.
-
+* `image-id`: *Required.* Path to the file containing the ID of the
+Docker image to be released.
 * `version`: *Optional.* Path to the file containing the version for
    the new release. If the version is not set, it will use the next version.
-
 
 ## Development
 

--- a/resource/check
+++ b/resource/check
@@ -32,6 +32,15 @@ export AWS_SECRET_ACCESS_KEY
 AWS_SESSION_TOKEN=$(jq -r '.source.aws_session_token // ""' < "$payload")
 export AWS_SESSION_TOKEN
 
+mkdir -p ~/.aws/
+echo "[default]
+aws_access_key_id=$AWS_ACCESS_KEY_ID
+aws_secret_access_key=$AWS_SECRET_ACCESS_KEY
+aws_session_token=$AWS_SESSION_TOKEN
+" > ~/.aws/credentials
+
+export CATAPULT_AWS_PROFILE="default"
+
 if [ -z "$name" ]; then
   echo "parameter 'name' is required"
   exit 1

--- a/resource/in
+++ b/resource/in
@@ -1,7 +1,7 @@
 #!/bin/sh
 # vim: set ft=sh
 
-set -e
+set -ex
 
 exec 3>&1 # make stdout available as fd 3 for the result
 exec 1>&2 # redirect all output to stderr for logging
@@ -40,6 +40,18 @@ export AWS_ACCESS_KEY_ID
 
 AWS_SECRET_ACCESS_KEY=$(jq -r '.source.aws_secret_access_key // ""' < "$payload")
 export AWS_SECRET_ACCESS_KEY
+
+AWS_SESSION_TOKEN=$(jq -r '.source.aws_session_token // ""' < "$payload")
+export AWS_SESSION_TOKEN
+
+mkdir -p ~/.aws/
+echo "[default]
+aws_access_key_id=$AWS_ACCESS_KEY_ID
+aws_secret_access_key=$AWS_SECRET_ACCESS_KEY
+aws_session_token=$AWS_SESSION_TOKEN
+" > ~/.aws/credentials
+
+export CATAPULT_AWS_PROFILE="default"
 
 AWS_SESSION_TOKEN=$(jq -r '.source.aws_session_token // ""' < "$payload")
 export AWS_SESSION_TOKEN

--- a/resource/out
+++ b/resource/out
@@ -1,7 +1,7 @@
 #!/bin/sh
 # vim: set ft=sh
 
-set -e
+set -ex
 
 exec 3>&1 # make stdout available as fd 3 for the result
 exec 1>&2 # redirect all output to stderr for logging
@@ -26,6 +26,8 @@ name=$(jq -r '.source.name' < "$payload")
 bucket=$(jq -r '.source.bucket // ""' < "$payload")
 # commit ref to release
 repository=$(jq -r '.params.repository // ""' < "$payload")
+# file containing the image ID to release
+image_id_file=$(jq -r '.params.image_id // ""' < "$payload")
 # new version
 version_file=$(jq -r '.params.version // ""' < "$payload")
 # flag for deploy releases
@@ -36,16 +38,25 @@ export environment
 # bucket containing the environment deploys
 deploy_bucket=$(jq -r ".source.deploy_bucket" < "$payload")
 export deploy_bucket
-# file containing the image ID to release
-image_id_file=$(jq -r ".params.image_id" < "$payload")
 
 # AWS credentials
 AWS_ACCESS_KEY_ID=$(jq -r '.source.aws_access_key_id // ""' < "$payload")
 export AWS_ACCESS_KEY_ID
+
 AWS_SECRET_ACCESS_KEY=$(jq -r '.source.aws_secret_access_key // ""' < "$payload")
 export AWS_SECRET_ACCESS_KEY
+
 AWS_SESSION_TOKEN=$(jq -r '.source.aws_session_token // ""' < "$payload")
 export AWS_SESSION_TOKEN
+
+mkdir -p ~/.aws/
+echo "[default]
+aws_access_key_id=$AWS_ACCESS_KEY_ID
+aws_secret_access_key=$AWS_SECRET_ACCESS_KEY
+aws_session_token=$AWS_SESSION_TOKEN
+" > ~/.aws/credentials
+
+export CATAPULT_AWS_PROFILE="default"
 
 if [ -z "$name" ]; then
   echo "parameter 'name' is required"
@@ -63,8 +74,8 @@ if [ -n "$version_file" ]; then
 fi
 
 image_id_arg=""
-if [ -z "$image_id_file" ]; then
-  image_id_arg=--iamge-id=$(cat "$image_id_file")
+if [ -n "$image_id_file" ]; then
+  image_id_arg=--image-id=$(cat "$image_id_file")
 fi
 
 
@@ -89,7 +100,7 @@ else
       exit 1
     fi
 
-    catapult release.new "$name" "$version_arg" "$image_id_arg" --yes > "$release"
+    catapult release.new "$name" $version_arg $image_id_arg --yes > "$release"
 fi
 
 version=$(jq -r '.version' < "$release")

--- a/resource/out
+++ b/resource/out
@@ -36,6 +36,8 @@ export environment
 # bucket containing the environment deploys
 deploy_bucket=$(jq -r ".source.deploy_bucket" < "$payload")
 export deploy_bucket
+# file containing the image ID to release
+image_id_file=$(jq -r ".params.image_id" < "$payload")
 
 # AWS credentials
 AWS_ACCESS_KEY_ID=$(jq -r '.source.aws_access_key_id // ""' < "$payload")
@@ -60,6 +62,12 @@ if [ -n "$version_file" ]; then
   version_arg=--version=$(cat "$version_file")
 fi
 
+image_id_arg=""
+if [ -z "$image_id_file" ]; then
+  image_id_arg=--iamge-id=$(cat "$image_id_file")
+fi
+
+
 if [ -n "$bucket" ]; then
   export CATAPULT_BUCKET_RELEASES=$bucket
 fi
@@ -76,7 +84,12 @@ if [ "$is_deploy" = "true" ]; then
 
     catapult deploy.start "$name" "$environment" "$version_arg" --bucket="$deploy_bucket" --yes > "$release"
 else
-    catapult release.new "$name" "$version_arg" --yes > "$release"
+    if [ -z "$image_id_file" ]; then
+      echo "parameter 'image_id_file' is required when 'is_deploy' is false"
+      exit 1
+    fi
+
+    catapult release.new "$name" "$version_arg" "$image_id_arg" --yes > "$release"
 fi
 
 version=$(jq -r '.version' < "$release")


### PR DESCRIPTION
Add a new argument `--image-id` to command `release.new`, this will avoid the `docker pull` needed to get the image digest attached to all release objects.

The new argument is also supported in Concourse resource, fixing the action `put` that allows releases to be created automatically.