### PR TITLE
Improve release.ls output

### DIFF
--- a/catapult/config.py
+++ b/catapult/config.py
@@ -18,3 +18,6 @@ GIT_REPO = os.environ.get("CATAPULT_GIT_REPO", "./")
 CATAPULT_SESSION = os.environ.get(
     "CATAPULT_SESSION", os.path.join(_HOME_PATH, ".catapult")
 )
+
+
+IS_CONCOURSE = bool(os.environ.get("IS_CONCOURSE"))

--- a/catapult/deploy.py
+++ b/catapult/deploy.py
@@ -2,7 +2,6 @@
 Commands to manage deployments.
 """
 import logging
-import sys
 from datetime import datetime
 
 import dataclasses
@@ -43,8 +42,7 @@ def start(
         release = get_release(client, name, int(version))
 
     if release is None:
-        LOG.critical("Release not found")
-        sys.exit(1)
+        utils.fatal("Release not found")
 
     if bucket is None:
         bucket = utils.get_config()["deploy"][env]["s3_bucket"]
@@ -80,8 +78,7 @@ def start(
 
         if not rollback:
             utils.warning("Missing flag --rollback\n")
-            utils.error("Aborted!\n")
-            sys.exit(1)
+            utils.fatal("Aborted!")
 
     if not yes:
 
@@ -92,13 +89,11 @@ def start(
             )
 
             if not ok:
-                utils.error("Aborted!\n")
-                sys.exit(1)
+                utils.fatal("Aborted!")
 
         ok = utils.confirm("Are you sure you want to start this deployment?")
         if not ok:
-            utils.error("Aborted!\n")
-            sys.exit(1)
+            utils.fatal("Aborted!")
 
     put_release(client, bucket, name, release)
     utils.success("Started new deployment :rocket:\n")
@@ -127,8 +122,7 @@ def current(_, name, env, bucket=None):
         utils.printfmt(last_deploy)
 
     else:
-        LOG.critical("Release does not exist")
-        sys.exit(1)
+        utils.fatal("Release does not exist")
 
 
 deploy = invoke.Collection("deploy", start, current)

--- a/catapult/deploy.py
+++ b/catapult/deploy.py
@@ -6,9 +6,10 @@ from datetime import datetime
 
 import dataclasses
 import invoke
+import pygit2 as git
 
-from catapult import utils
-from catapult.release import get_release, get_releases, put_release
+from catapult import config, utils
+from catapult.release import ActionType, get_release, get_releases, put_release
 
 LOG = logging.getLogger(__name__)
 
@@ -60,12 +61,15 @@ def start(
         changelog_text = changelog.text
         is_rollback = changelog.rollback
 
+    action_type = ActionType.automated if config.IS_CONCOURSE else ActionType.manual
+
     release = dataclasses.replace(
         release,
         changelog=changelog_text,
         timestamp=datetime.now(),
-        author=utils.get_author(repo),
+        author=utils.get_author(repo, git.Oid(hex=release.commit)),
         rollback=is_rollback,
+        action_type=action_type,
     )
 
     utils.printfmt(release)

--- a/catapult/projects.py
+++ b/catapult/projects.py
@@ -30,6 +30,7 @@ class Project(NamedTuple):
     age: timedelta
     timestamp: datetime
     commit: str
+    action_type: str
     contains: Optional[bool]
     permission: Optional[bool]
 
@@ -130,6 +131,7 @@ def ls(_, contains=None, sort=None, reverse=False, only=None, permissions=False)
                 ),
                 env_name="",
                 permission=can_release.get(name),
+                action_type=release.action_type.name
             )
         )
 
@@ -154,6 +156,7 @@ def ls(_, contains=None, sort=None, reverse=False, only=None, permissions=False)
                         else None
                     ),
                     permission=can_deploy.get(env_name, {}).get(name),
+                    action_type=release.action_type.name
                 )
             )
 

--- a/catapult/projects.py
+++ b/catapult/projects.py
@@ -8,11 +8,10 @@ from operator import itemgetter
 from typing import NamedTuple, Optional
 
 import invoke
-import pygit2 as git
 
 from catapult import utils
 from catapult.config import AWS_MFA_DEVICE
-from catapult.release import InvalidRelease, Release
+from catapult.release import InvalidRelease, release_contains
 from catapult.release import _get_release as get_release
 
 LOG = logging.getLogger(__name__)
@@ -38,7 +37,7 @@ class Project(NamedTuple):
 @invoke.task(
     default=True,
     help={
-        "contains": "Full SHA-1 hash of a commit in the current repo",
+        "contains": "commit hash or revision of a commit, eg `bcc31bc`, `HEAD`, `some_branch`",
         "sort": "comma-separated list of fields by which to sort the output, eg `timestamp,name`",
         "reverse": "reverse-sort the output",
         "only": "comma-separated list of apps to list",
@@ -62,8 +61,8 @@ def ls(_, contains=None, sort=None, reverse=False, only=None, permissions=False)
     optional_columns = {"contains": bool(contains), "permission": bool(permissions)}
 
     if contains:
-        contains_oid = git.Oid(hex=contains)
         repo = utils.git_repo()
+        contains_oid = utils.revparse(repo, contains)
         if contains_oid not in repo:
             raise Exception(f"Commit {contains_oid} does not exist in repo")
 
@@ -124,9 +123,11 @@ def ls(_, contains=None, sort=None, reverse=False, only=None, permissions=False)
                 timestamp=release.timestamp,
                 age=now - release.timestamp,
                 type=ProjectType.release,
-                contains=release_contains(repo, release, contains_oid, name)
-                if contains
-                else None,
+                contains=(
+                    release_contains(repo, release, contains_oid, name)
+                    if contains
+                    else None
+                ),
                 env_name="",
                 permission=can_release.get(name),
             )
@@ -147,9 +148,11 @@ def ls(_, contains=None, sort=None, reverse=False, only=None, permissions=False)
                     age=now - deploy.timestamp,
                     type=ProjectType.deploy,
                     env_name=env_name,
-                    contains=release_contains(repo, deploy, contains_oid, name)
-                    if contains
-                    else None,
+                    contains=(
+                        release_contains(repo, deploy, contains_oid, name)
+                        if contains
+                        else None
+                    ),
                     permission=can_deploy.get(env_name, {}).get(name),
                 )
             )
@@ -174,23 +177,6 @@ def ls(_, contains=None, sort=None, reverse=False, only=None, permissions=False)
         project_dicts.sort(key=itemgetter(*sort_keys), reverse=reverse)
 
     utils.printfmt(project_dicts, tabular=True)
-
-
-def release_contains(
-    repo: git.Repository, release: Release, commit_oid: git.Oid, name: str
-):
-    if not release.commit:
-        LOG.warning(f"{name} has a null commit ref")
-        return "?"
-
-    release_oid = git.Oid(hex=release.commit)
-    try:
-        in_release = utils.commit_contains(repo, release_oid, commit_oid)
-    except git.GitError as e:
-        LOG.warning(f"Repo: [{repo.workdir}], Error: [{repr(e)}], Project: [{name}]")
-        in_release = "?"
-
-    return in_release
 
 
 def check_perms(iam_client, bucket_name, project_names):

--- a/catapult/release.py
+++ b/catapult/release.py
@@ -434,11 +434,9 @@ def find(_, name, commit=None):
     client = utils.s3_client()
 
     releases = {release.commit: release for release in get_releases(client, name)}
-    print(len(releases))
 
     release = None
     for log in utils.git_log(repo):
-        print(oid.hex, release and release.commit, log.hex)
         if log.hex in releases:
             release = releases[log.hex]
 

--- a/catapult/release.py
+++ b/catapult/release.py
@@ -4,11 +4,12 @@ Commands to manage releases.
 import json
 import logging
 import os
-import sys
-from datetime import datetime
+from datetime import datetime, timezone
+from typing import Optional
 
 import dataclasses
 import invoke
+import pygit2 as git
 import pytz
 
 from catapult import utils
@@ -208,14 +209,14 @@ def put_release(client, bucket, key, release):
     )
 
 
-def _get_image_id(ctx, commit, *, name, image_name):
+def _get_image_id(ctx, commit: git.Oid, *, name: str, image_name: Optional[str]):
     image_base = utils.get_config()["release"]["docker_repository"]
 
     if image_name is None:
         image_prefix = utils.get_config()["release"]["docker_image_prefix"]
         image_name = f"{image_prefix}{name}"
 
-    image = f"{image_base}/{image_name}:ref-{commit}"
+    image = f"{image_base}/{image_name}:ref-{commit.hex}"
 
     LOG.info(f"Pulling {image}")
     res = ctx.run(f"docker pull {image}", hide="out")
@@ -240,8 +241,7 @@ def current(_, name):
         utils.printfmt(release)
 
     else:
-        LOG.critical("Release does not exist")
-        sys.exit(1)
+        utils.fatal("Release does not exist")
 
 
 @invoke.task(help={"name": "project's name", "version": "release's version"})
@@ -256,22 +256,51 @@ def get(_, name, version):
         utils.printfmt(release)
 
     else:
-        LOG.critical("Release does not exist")
-        sys.exit(1)
+        utils.fatal("Release does not exist")
 
 
-@invoke.task(help={"name": "project's name", "last": "return only the last n releases"})
+@invoke.task(
+    help={
+        "name": "project's name",
+        "last": "return only the last n releases",
+        "contains": "commit hash or revision of a commit, eg `bcc31bc`, `HEAD`, `some_branch`",
+    }
+)
 @utils.require_2fa
-def ls(_, name, last=None):
+def ls(_, name, last=None, contains=None):
     """
     Show all the project's releases.
     """
+    repo = None
+    contains_oid = None
+
+    if contains:
+        repo = utils.git_repo()
+        contains_oid = utils.revparse(repo, contains)
+        if contains_oid not in repo:
+            raise Exception(f"Commit {contains_oid} does not exist in repo")
+
     releases = get_releases(utils.s3_client(), name)
 
-    if last is not None:
-        releases = list(releases)[: int(last)]
+    release_data = []
+    now = datetime.now(tz=timezone.utc)
+    last = int(last) if last else None
+    for i, rel in enumerate(releases):
+        if i == last:
+            break
+        release_dict = {
+            "version": rel.version,
+            "commit": rel.commit,
+            "timestamp": rel.timestamp,
+            "age": now - rel.timestamp,
+            "author": rel.author,
+            "rollback": rel.rollback,
+        }
+        if contains:
+            release_dict["contains"] = release_contains(repo, rel, contains_oid, name)
+        release_data.append(release_dict)
 
-    utils.printfmt(list(releases))
+    utils.printfmt(release_data, tabular=True)
 
 
 @invoke.task(
@@ -306,31 +335,31 @@ def new(
 
     client = utils.s3_client()
     latest = next(get_releases(client, name), None)
+    latest_oid = git.Oid(hex=latest.commit) if latest else None
 
     if commit is None:
-        # get last commit
-        commit = next(utils.git_log(repo), None)
-        commit = commit and commit.hex
+        commit = "HEAD"
+
+    commit_oid = utils.revparse(repo, commit)
 
     if version is None:
-        # crate next version
+        # create next version
         version = 1 if latest is None else latest.version + 1
 
     else:
         version = int(version)
 
     if image_id is None:
-        image_id = _get_image_id(ctx, commit, name=name, image_name=image_name)
+        image_id = _get_image_id(ctx, commit_oid, name=name, image_name=image_name)
 
         if image_id is None:
-            LOG.critical("Image not found")
-            sys.exit(1)
+            utils.fatal("Image not found")
 
-    changelog = utils.changelog(repo, commit, latest and latest.commit)
+    changelog = utils.changelog(repo, commit_oid, latest_oid)
 
     release = Release(
         version=version,
-        commit=commit,
+        commit=commit_oid.hex,
         changelog=changelog.text,
         version_id="",
         image=image_id,
@@ -349,8 +378,7 @@ def new(
 
         if not rollback:
             utils.warning("Missing flag --rollback\n")
-            utils.error("Aborted!\n")
-            sys.exit(1)
+            utils.fatal("Aborted!")
 
     if not yes:
 
@@ -361,12 +389,11 @@ def new(
             )
 
             if not ok:
-                utils.error("Aborted!\n")
-                sys.exit(1)
+                utils.fatal("Aborted!")
 
         ok = utils.confirm("Are you sure you want to create this release?")
         if not ok:
-            sys.exit(1)
+            utils.fatal("Aborted!")
 
     put_release(client, _get_bucket(), name, release)
 
@@ -382,20 +409,26 @@ def new(
 @utils.require_2fa
 def find(_, name, commit=None):
     """
-    Search a release from the commit hash.
+    Find the first release containing a specific commit.
     """
+    if commit is None:
+        commit = "HEAD"
+
     repo = utils.git_repo()
-    commit = commit or next(utils.git_log(repo)).hex
+    oid = utils.revparse(repo, commit)
 
     client = utils.s3_client()
 
     releases = {release.commit: release for release in get_releases(client, name)}
+    print(len(releases))
 
     release = None
     for log in utils.git_log(repo):
-        release = releases.get(log.hex, release)
+        print(oid.hex, release and release.commit, log.hex)
+        if log.hex in releases:
+            release = releases[log.hex]
 
-        if commit == log.hex:
+        if oid.hex == log.hex:
             break
 
     if release:
@@ -440,6 +473,23 @@ def log(_, name, git_range, resolve=False):
         text = utils.changelog(repo, end, start).text
 
     print(text)
+
+
+def release_contains(
+    repo: git.Repository, release: Release, commit_oid: git.Oid, name: str
+):
+    if not release.commit:
+        LOG.warning(f"{name} has a null commit ref")
+        return "?"
+
+    release_oid = git.Oid(hex=release.commit)
+    try:
+        in_release = utils.commit_contains(repo, release_oid, commit_oid)
+    except git.GitError as e:
+        LOG.warning(f"Repo: [{repo.workdir}], Error: [{repr(e)}], Project: [{name}]")
+        in_release = "?"
+
+    return in_release
 
 
 release = invoke.Collection("release", current, ls, new, find, get, log)

--- a/resource/check
+++ b/resource/check
@@ -6,6 +6,7 @@ set -ex
 exec 3>&1 # make stdout available as fd 3 for the result
 exec 1>&2 # redirect all output to stderr for logging
 
+export IS_CONCOURSE=1
 
 # save the input in a tmp file
 payload=$(mktemp /tmp/resource-check.XXXXXX)

--- a/resource/in
+++ b/resource/in
@@ -6,6 +6,8 @@ set -ex
 exec 3>&1 # make stdout available as fd 3 for the result
 exec 1>&2 # redirect all output to stderr for logging
 
+export IS_CONCOURSE=1
+
 destination=$1
 
 if [ -z "$destination" ]; then

--- a/resource/out
+++ b/resource/out
@@ -106,7 +106,7 @@ else
       exit 1
     fi
 
-    catapult release.new "$name" $version_arg $image_id_arg --yes > "$release"
+    catapult release.new "$name" "$version_arg" "$image_id_arg" --yes > "$release"
 fi
 
 version=$(jq -r '.version' < "$release")

--- a/resource/out
+++ b/resource/out
@@ -6,6 +6,8 @@ set -ex
 exec 3>&1 # make stdout available as fd 3 for the result
 exec 1>&2 # redirect all output to stderr for logging
 
+export IS_CONCOURSE=1
+
 source=$1
 
 if [ -z "$source" ]; then


### PR DESCRIPTION
The output of `release.ls` is now formatted as a human-readable table, and it now accepts the `--contains` parameter (similar to `projects.ls`) that adds an additional field to the output stating whether that release contains the specified commit.

This also neatens fatal logging, and adds support for git revparse in places that previously only accepted a full 40 char commit hash.

Also I ran shellcheck on the concourse resource scripts and applied the suggested changes.