### PR TITLE
Update the recommended version of libgit2 in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Requires the development version of `openssl` to be installed.
   ```
 
 ```bash
-wget https://github.com/libgit2/libgit2/archive/v0.27.0.tar.gz
-tar xzf v0.27.0.tar.gz
-cd libgit2-0.27.0/
+wget https://github.com/libgit2/libgit2/archive/v1.0.1.tar.gz
+tar xzf v1.0.1.tar.gz
+cd libgit2-1.0.1/
 cmake .
 make
 sudo make install


### PR DESCRIPTION
The README tells the user to install version `0.27.0` of `libgit2-dev` but `pygit2==1.2.1` requires `libgit2==1.0.x`. See https://github.com/libgit2/pygit2/issues/999 for some more context.

This PR updates the README to tell the user to install the correct version of `libgit2` from source.

Note that if installing `catapult` on linux with pip >= 19 with an outdated version of `libgit2`, `pygit2` will still be installed because pip will use a prebuilt binary "wheel". 