### PR TITLE
add clarification about `CATAPULT_GIT_REPO`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Set these environment variables to configure catapult:
 
 * `CATAPULT_GIT_REPO`: path to the git repository (default: `./`).
   **!!! If this is not set, catapult should be run inside the git repository !!!**
+  Note, this is the path to the git repository you are deploying from, not the catapult repository
 * `CATAPULT_AWS_PROFILE`: use this profile from your credential file. Required.
 * `CATAPULT_AWS_MFA_DEVICE`: ARN of the MFA device used to get the session credentials. You can find this on the "Security Credentials" tab of [your user account in IAM](https://console.aws.amazon.com/iam/home).
 


### PR DESCRIPTION
When I was setting up catapult, I thought I had to set `CATAPULT_GIT_REPO` to the path to where I cloned this repository to.

Added a note to make it clearer.