### PR TITLE
Allow reverse-sorting by any field

### DIFF
--- a/catapult/integrations/github.py
+++ b/catapult/integrations/github.py
@@ -10,6 +10,7 @@ import re
 import requests
 
 from catapult.integrations.git import BaseGit, PullRequest, PullRequestState
+from catapult import utils
 
 GH_ENDPOINT = "https://api.github.com/graphql"
 
@@ -47,6 +48,12 @@ class GitHub(BaseGit):
         res = requests.post(
             GH_ENDPOINT, json=req_data, headers={"Authorization": f"bearer {gh_token}"}
         ).json()
+
+        for error in res.get("errors", []):
+            err_type = error.get("type")
+            err_msg = error.get("message")
+            utils.warning(f"{err_type}: {err_msg}\n")
+            utils.warning(f"{error}\n")
 
         pr_details = res["data"]["repository"]["pullRequest"]
 

--- a/catapult/tickets.py
+++ b/catapult/tickets.py
@@ -16,8 +16,10 @@ from catapult.projects import format_projects, list_projects
     help={
         "ticket_id": "Identifier of the ticket, eg `ch12345`, `SBDEV-2808`",
         "author": "include the author of the release/deploy",
-        "sort": "comma-separated list of fields by which to sort the output, eg `timestamp,name`",
-        "reverse": "reverse-sort the output",
+        "sort": (
+            "comma-separated list of fields by which to sort the output, eg `timestamp,name`. "
+            "Prepend a field name with `!` to reverse the sorting by that field."
+        ),
         "only": "comma-separated list of apps to list",
         "permissions": "check if you have permission to release/deploy",
         "utc": "list timestamps in UTC instead of local timezone",
@@ -32,7 +34,6 @@ def find(
     ticket_id,
     author=False,
     sort=None,
-    reverse=False,
     only=None,
     permissions=False,
     utc=False,
@@ -68,12 +69,7 @@ def find(
             profile=profile,
         )
         format_projects(
-            projects,
-            author=author,
-            contains=True,
-            sort=sort,
-            reverse=reverse,
-            permissions=permissions,
+            projects, author=author, contains=True, sort=sort, permissions=permissions
         )
 
 

--- a/catapult/utils.py
+++ b/catapult/utils.py
@@ -479,8 +479,8 @@ class Changelog:
 
 def changelog(
     repo: git.repository.Repository,
-    latest: git.Oid,
-    prev: git.Oid,
+    latest: Optional[git.Oid],
+    prev: Optional[git.Oid],
     *,
     keep_only_files: Optional[List[str]] = None,
     keep_only_commits: Optional[List[str]] = None,


### PR DESCRIPTION
Allows the output of `projects.ls`, `release.ls`, `deploy.ls` to be sorted by any fields in any direction, eg

`catapult projects.ls -s 'name,!age'`

Note: `!` may have a special meaning to your shell, so the string should probably be quoted.