### PR TITLE
Truncate long changelogs

### DIFF
--- a/catapult/deploy.py
+++ b/catapult/deploy.py
@@ -88,7 +88,7 @@ def start(
             repo, release.commit, None, keep_only_commits=commits
         )
 
-        changelog_text = changelog.short_text
+        changelog_text = changelog.truncated_text
         is_rollback = release.rollback
 
     else:
@@ -100,7 +100,7 @@ def start(
             keep_only_commits=commits,
         )
 
-        changelog_text = changelog.short_text
+        changelog_text = changelog.truncated_text
         is_rollback = changelog.rollback
 
     action_type = ActionType.automated if config.IS_CONCOURSE else ActionType.manual

--- a/catapult/release.py
+++ b/catapult/release.py
@@ -430,7 +430,7 @@ def new(
     release = Release(
         version=version,
         commit=commit_oid.hex,
-        changelog=changelog.short_text,
+        changelog=changelog.truncated_text,
         version_id="",
         image=image_id,
         timestamp=datetime.now(),


### PR DESCRIPTION
This should fix #10 by truncating large changelogs.

This change is made on the basis that the changelog is for informational purposes only, and a full changelog can be obtained from the git repo.