### PR TITLE
Changed emojize parameter, pin emoji to a newer version

### DIFF
--- a/catapult/utils.py
+++ b/catapult/utils.py
@@ -138,7 +138,7 @@ def confirm(prompt, style=TextStyle.plain):
 def style_text(text: Any, style: TextStyle) -> str:
     text = str(text)
     return termcolor.colored(
-        emoji.emojize(text, use_aliases=True), style.fg, style.bg, attrs=style.attrs
+        emoji.emojize(text, language="alias"), style.fg, style.bg, attrs=style.attrs
     )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto3==1.23.10
 colorama==0.4.1
 dataclasses==0.6
-emoji==0.5.1
+emoji==2.0.0
 invoke==1.5.0
 pygit2==1.2.1
 pytz==2018.5


### PR DESCRIPTION
This fixes an issue created by the release of emoji v2.0.0, where the `as_alias` parameter was removed.