### PR TITLE
Upgrade python dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,27 +7,27 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = "^3.7"
-boto3 = "1.23.10"
+boto3 = "1.24.42"
 pygit2 = "1.9.2"  # Supports libgit2 v1.4.3 - which is the version available for Apline Linux
                   # https://github.com/libgit2/pygit2/blob/master/CHANGELOG.rst#192-2022-05-24
-colorama = "0.4.1"
+colorama = "0.4.5"
 dataclasses = "0.6"
 emoji = "2.0.0"
-invoke = "1.5.0"
-pytz = "2018.5"
-requests = "2.23.0"
-tabulate = "0.8.9"
+invoke = "1.7.1"
+pytz = "2022.1"
+requests = "2.28.1"
+tabulate = "0.8.10"
 termcolor = "1.1.0"
-toml = "0.10.0"
-tzlocal = "2.0.0"
-wrapt = "1.10.11"
+toml = "0.10.2"
+tzlocal = "4.2"
+wrapt = "1.14.1"
 
 [tool.poetry.dev-dependencies]
 black = "22.6.0"
-freezegun = "0.3.15"
-moto = "3.1.14"
-python-dateutil = "2.8.1"
-testfixtures = "6.14.1"
+freezegun = "1.2.1"
+moto = "3.1.16"
+python-dateutil = "2.8.2"
+testfixtures = "7.0.0"
 pytest = "^7.1.2"
 
 [build-system]

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from unittest import mock
 
 import boto3
+import pytest
 import pytz
 from freezegun import freeze_time
 from moto import mock_s3
@@ -11,6 +12,8 @@ from testfixtures import compare
 
 os.environ["CATAPULT_AWS_PROFILE"] = "test_profile"
 os.environ["CATAPULT_AWS_MFA_DEVICE"] = "arn"
+# TODO: Specify region directly in the API calls
+os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
 
 
 from catapult import release


### PR DESCRIPTION
This bumps all python dependencies to the latest known versions that work.

In addition, the environment variable `AWS_DEFAULT_REGION` is set to satisfy a `moto` change, although long-term we should probably specify the AWS region in our test calls.