### PR TITLE
Set maximum Python version to 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Fede Figus <federico.figus@tessian.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = ">=3.7,<=3.9"
 boto3 = "1.12.32"
 pygit2 = "1.9.2"  # Supports libgit2 v1.4.3 - which is the version available for Apline Linux
                   # https://github.com/libgit2/pygit2/blob/master/CHANGELOG.rst#192-2022-05-24


### PR DESCRIPTION
Due to the dependency downgrade, catapult is no longer compatible with 3.10. This sets the maximum to `<=3.9` to prevent accidental installation with 3.10.