### PR TITLE
Correctly set maximum Python version to 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Fede Figus <federico.figus@tessian.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = ">=3.7,<=3.9"
+python = ">=3.7,<3.10"
 boto3 = "1.12.32"
 pygit2 = "1.9.2"  # Supports libgit2 v1.4.3 - which is the version available for Apline Linux
                   # https://github.com/libgit2/pygit2/blob/master/CHANGELOG.rst#192-2022-05-24


### PR DESCRIPTION
When trying to install with Python 3.9.x, the installation fails with

```
$ pipx install git+https://github.com/tessian/catapult --python ~/.pyenv/versions/3.9.10/bin/python
ERROR: Package 'catapult' requires a different Python: 3.9.10 not in '<=3.9,>=3.7'
```
This updates `pyproject.toml` to specify `">=3.7,<3.10"`

```
$ pipx install ~/repos/catapult/ --python ~/.pyenv/versions/3.9.10/bin/python
  installed package catapult 1.0.1, installed using Python 3.9.10
  These apps are now globally available
    - catapult
done! ✨ 🌟 ✨
```

I don't think this needs a version bump, as it'll only affect new installs of `catapult`.
