### PR TITLE
Slim down slack alerts; fix icon

### DIFF
--- a/resource/in
+++ b/resource/in
@@ -138,6 +138,11 @@ if [ "$is_deploy" = "true" ]; then
         "title_link": env.PIPELINE_URL,
         "fields": [
           {
+            "title": "Environment",
+            "value": env.environment,
+            "short": true
+          },
+          {
             "title": "Version",
             "value": env.version,
             "short": true
@@ -145,26 +150,16 @@ if [ "$is_deploy" = "true" ]; then
           {
             "title": "Concourse",
             "value": env.build_url,
-            "short": true
+            "short": false
           },
           {
             "title": "Commit :github:",
-            "value": env.commit,
-            "short": true
-          },
-          {
-            "title": "Environment",
-            "value": env.environment,
-            "short": true
-          },
-          {
-            "title": "Changelog",
-            "value": "```\n\(env.changelog)\n```",
+            "value": "`\(env.commit)`",
             "short": false
           }
         ],
         "footer": "Concourse CI",
-        "footer_icon": "https://concourse-ci.org/images/trademarks/concourse-black.png",
+        "footer_icon": "https://user-images.githubusercontent.com/5238952/56868786-3c245a80-69c5-11e9-8714-01ac97c7b921.png",
         "ts": env.message_ts | tonumber
       }
     ]' > "$destination/message.json"
@@ -187,21 +182,16 @@ else
           {
             "title": "Concourse",
             "value": env.build_url,
-            "short": true
+            "short": false
           },
           {
             "title": "Commit :github:",
-            "value": env.commit,
-            "short": true
-          },
-          {
-            "title": "Changelog",
-            "value": "```\n\(env.changelog)\n```",
+            "value": "`\(env.commit)`",
             "short": false
           }
         ],
         "footer": "Concourse CI",
-        "footer_icon": "https://concourse-ci.org/images/trademarks/concourse-black.png",
+        "footer_icon": "https://user-images.githubusercontent.com/5238952/56868786-3c245a80-69c5-11e9-8714-01ac97c7b921.png",
         "ts": env.message_ts | tonumber
       }
     ]' > "$destination/message.json"


### PR DESCRIPTION
This removes the changelog, which is mostly noise. It also fixes the Concourse icon, tweaks some of the short/long fields (which control whether the field gets a half-width or full-width table cell), and adds `formatting` around the commit hash.

----

# Old style message:
![Screenshot from 2023-02-13 12-03-10](https://user-images.githubusercontent.com/56871210/218454047-1f439b8f-fdf8-4151-a13f-ac0f2c31f7ec.png)

----

# New style message:
![Screenshot from 2023-02-13 12-01-21](https://user-images.githubusercontent.com/56871210/218454073-f58a78c5-ddf1-4143-a91e-e061ca829539.png)

