### PR TITLE
Use version defined in pyproject.toml

### DIFF
--- a/catapult/__main__.py
+++ b/catapult/__main__.py
@@ -13,7 +13,8 @@ from catapult.projects import projects
 from catapult.release import release
 from catapult.tickets import tickets
 
-__version__ = "0.1"
+from importlib import metadata
+__version__ = metadata.version(__package__)
 
 root = invoke.Collection()
 

--- a/catapult/__main__.py
+++ b/catapult/__main__.py
@@ -4,6 +4,7 @@ Collection of tasks for *catapult*.
 import logging
 import os
 import sys
+from importlib import metadata
 
 import boto3
 import invoke
@@ -13,7 +14,6 @@ from catapult.projects import projects
 from catapult.release import release
 from catapult.tickets import tickets
 
-from importlib import metadata
 __version__ = metadata.version(__package__)
 
 root = invoke.Collection()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "catapult"
-version = "1.0.3"
+version = "1.0.4"
 description = "CLI Tool to create, deploy, and manage releases."
 authors = ["Fede Figus <federico.figus@tessian.com>"]
 license = "MIT"


### PR DESCRIPTION
# Description

The version of the CLI is hardcoded to `0.1`

## What is the expected behaviour?

The version should be the same as defined in pyproject.toml, for instance:
https://github.com/Tessian/catapult/blob/0d0ac2da78dc07128c18f04798a7a5829db8ded4/pyproject.toml#L1-L4

```sh
catapult -V
catapult 1.0.3
```

## What is the current behaviour?

The version of the CLI is hardcoded to `0.1`

```sh
catapult -V
catapult 0.1
```
