### PR TITLE
Revert "Use version defined in pyproject.toml"

### DIFF
--- a/catapult/__main__.py
+++ b/catapult/__main__.py
@@ -4,7 +4,6 @@ Collection of tasks for *catapult*.
 import logging
 import os
 import sys
-from importlib import metadata
 
 import boto3
 import invoke
@@ -14,7 +13,7 @@ from catapult.projects import projects
 from catapult.release import release
 from catapult.tickets import tickets
 
-__version__ = metadata.version(__package__)
+__version__ = "0.1"
 
 root = invoke.Collection()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "catapult"
-version = "1.0.4"
+version = "1.0.3"
 description = "CLI Tool to create, deploy, and manage releases."
 authors = ["Fede Figus <federico.figus@tessian.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "catapult"
-version = "1.0.3"
+version = "1.0.5"
 description = "CLI Tool to create, deploy, and manage releases."
 authors = ["Fede Figus <federico.figus@tessian.com>"]
 license = "MIT"


### PR DESCRIPTION
Reverts Tessian/catapult#53

importlib.metadata is not available in 3.7. Introduced in 3.8 https://docs.python.org/3/library/importlib.metadata.html