### PR TITLE
Nahuel/sc 157174/update catapult to support docker-less deployments

### DIFF
--- a/catapult/release.py
+++ b/catapult/release.py
@@ -145,7 +145,6 @@ _DATETIME_MAX = pytz.utc.localize(datetime.max)
 
 def _get_bucket():
     config = utils.get_config()
-    print(config)
     if config:
         return config["release"]["s3_bucket"]
     return os.environ["CATAPULT_BUCKET_RELEASES"]

--- a/catapult/release.py
+++ b/catapult/release.py
@@ -31,7 +31,7 @@ class Release:
     version: int
     commit: str
     version_id: str
-    image: str
+    image: Optional[str]
     timestamp: datetime
     author: str
     changelog: str
@@ -145,6 +145,7 @@ _DATETIME_MAX = pytz.utc.localize(datetime.max)
 
 def _get_bucket():
     config = utils.get_config()
+    print(config)
     if config:
         return config["release"]["s3_bucket"]
     return os.environ["CATAPULT_BUCKET_RELEASES"]
@@ -369,6 +370,7 @@ def list_releases(name, last, contains, bucket=None, utc=False, profile=None):
         "commit": "git ref to build from.",
         "version": "new version",
         "image-id": "ID of the docker image to release.",
+        "has-image": "Whether the deployment includes a docker image.",
         "image-name": "name of the image to release (default to name)",
         "dry": "prepare a release without committing it",
         "yes": "Automatic yes to prompt",
@@ -386,6 +388,7 @@ def new(
     version=None,
     dry=False,
     yes=False,
+    has_image=True,
     image_name=None,
     image_id=None,
     rollback=False,
@@ -413,7 +416,7 @@ def new(
     else:
         version = int(version)
 
-    if image_id is None:
+    if image_id is None and has_image is True:
         image_id = _get_image_id(ctx, commit_oid, name=name, image_name=image_name)
 
         if image_id is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "catapult"
-version = "1.0.5"
+version = "1.0.6"
 description = "CLI Tool to create, deploy, and manage releases."
 authors = ["Fede Figus <federico.figus@tessian.com>"]
 license = "MIT"

--- a/resource/out
+++ b/resource/out
@@ -28,6 +28,8 @@ name=$(jq -r '.source.name' < "$payload")
 bucket=$(jq -r '.source.bucket // ""' < "$payload")
 # commit ref to release
 repository=$(jq -r '.params.repository // ""' < "$payload")
+# Whether the deployment includes a docker image
+has_image=$(jq -r '.source.has_image' < "$payload")
 # file containing the image ID to release
 image_id_file=$(jq -r '.params.image_id // ""' < "$payload")
 # new version
@@ -81,6 +83,15 @@ if [ -n "$version_file" ]; then
   version_arg=--version=$(cat "$version_file")
 fi
 
+has_image_arg=""
+if [ "${has_image}" == "true" ]; then
+  has_image_arg=--has-image
+fi
+if [ "${has_image}" == "false" ]; then
+  has_image_arg=--no-has-image
+fi
+
+
 image_id_arg=""
 if [ -n "$image_id_file" ]; then
   image_id_arg=--image-id=$(cat "$image_id_file")
@@ -103,12 +114,12 @@ if [ "$is_deploy" = "true" ]; then
 
     catapult deploy.start "$name" "$environment" "$version_arg" --bucket="$deploy_bucket" --yes > "$release"
 else
-    if [ -z "$image_id_file" ]; then
-      echo "parameter 'image_id_file' is required when 'is_deploy' is false"
+    if [ "$has_image" != "false" ] && [ -z "$image_id_file" ]; then
+      echo "parameter 'image_id_file' is required when 'is_deploy' is false and 'has_image' is true"
       exit 1
     fi
 
-    catapult release.new "$name" $version_arg $image_id_arg --yes > "$release"
+    catapult release.new "$name" $version_arg $image_id_arg $has_image_arg --yes > "$release"
 fi
 
 version=$(jq -r '.version' < "$release")

--- a/resource/out
+++ b/resource/out
@@ -86,8 +86,7 @@ fi
 has_image_arg=""
 if [ "${has_image}" == "true" ]; then
   has_image_arg=--has-image
-fi
-if [ "${has_image}" == "false" ]; then
+elif [ "${has_image}" == "false" ]; then
   has_image_arg=--no-has-image
 fi
 


### PR DESCRIPTION
At the moment, Catapult depends on docker images and it doesn't support services that don't have a Docker image.

This PR makes catapult capable of deploying any kind of artefact, not just docker images. This supports deploying the frontend using just S3 files, but can also be used to lambdas using zip files, etc.

This is an example of a very simple concourse pipeline where the Master job gets a repo and creates a version for it. Then the "Release" job handles the deployment. This is a super simplified version of what we do in real life.

![image](https://github.com/Tessian/catapult/assets/74601352/02921661-db15-4e28-8a43-b5b30825fc58)


![image](https://github.com/Tessian/catapult/assets/74601352/29b1be23-bcdf-4ac3-b4c6-b1bc343289f2)

I also tested this with the frontend-livefeed app, and it worked as expected.
Any other app can opt-in to no-docker-image deployments using this resource:

```yml
- name: release
    type: release
    source:
      name: frontend-livefeed-sc-157174
      <<: *aws_build_account_credentials
      bucket: bucket-name-for-releases
      has_image: false # <--- This lets us make docker-less deployments 💪
```